### PR TITLE
Add workflow files and licence

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,39 @@
+name: Linux
+
+on:
+  pull_request:
+    branches: [ "master" ]
+  workflow_dispatch:
+    branches: [ "master" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Checkout StdFuncs
+        uses: actions/checkout@v3
+        with:
+          repository: hitman-codehq/StdFuncs
+          path: StdFuncs
+      - name: Download Libraries
+        run: |
+          mv StdFuncs ..
+          gh run download --repo hitman-codehq/StdFuncs --name Linux-Libraries --dir ../StdFuncs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build
+        run: |
+          make
+      - name: Build Debug
+        run: |
+          make DEBUG=1
+      - name: Archive Executables
+        uses: actions/upload-artifact@v3
+        with:
+          name: Linux-Executables
+          path: |
+            Debug/ls
+            Release/ls

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,47 @@
+name: Windows
+
+on:
+  pull_request:
+    branches: [ "master" ]
+  workflow_dispatch:
+    branches: [ "master" ]
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Checkout StdFuncs
+        uses: actions/checkout@v3
+        with:
+          repository: hitman-codehq/StdFuncs
+          path: StdFuncs
+      - name: Download Libraries
+        run: |
+          mv StdFuncs ..
+          gh run download --repo hitman-codehq/StdFuncs --name Windows-Libraries --dir ../StdFuncs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v1.1
+        with:
+          vs-version: '16.0'
+      - name: Build
+        run: |
+          msbuild /p:Configuration=Release /p:Platform=x86
+          msbuild /p:Configuration=Release /p:Platform=x64
+      - name: Build Debug
+        run: |
+          msbuild /p:Configuration=Debug /p:Platform=x86
+          msbuild /p:Configuration=Debug /p:Platform=x64
+      - name: Archive Executables
+        uses: actions/upload-artifact@v3
+        with:
+          name: Windows-Executables
+          path: |
+            Win32/Debug/*.exe
+            x64/Debug/*.exe
+            Win32/Release/*.exe
+            x64/Release/*.exe

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.vs
+.vscode
+*.user
+build
+Debug
+Debug_OS4
+Release
+Release_OS4

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020-2021 Colin Ward AKA Hitman/Code HQ
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
These workflows will build debug and release builds of ls for Linux x86, and Windows x86 and x64 targets.