### PR TITLE
Update to v4 of actions/upload-artifact

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           make DEBUG=1
       - name: Archive Executables
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Linux-Executables
           path: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -37,7 +37,7 @@ jobs:
           msbuild /p:Configuration=Debug /p:Platform=x86
           msbuild /p:Configuration=Debug /p:Platform=x64
       - name: Archive Executables
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Windows-Executables
           path: |


### PR DESCRIPTION
v3 has been deprecated by GitHub and no longer functions.